### PR TITLE
Feat/fallback rpcs

### DIFF
--- a/chain_config_example.json
+++ b/chain_config_example.json
@@ -2,11 +2,13 @@
     "chains": [
         {
             "rpc_url": "MUMBAI WSS RPC HERE",
+            "fallback_rpcs":["MUMBAI WSS RPC HERE", "MUMBAI WSS RPC HERE"],
             "chain_id": 80001,
             "bridge_address": "0xf65484Cc0Ae4EBD92Cd6c4eb5fC61F17Edb9f2df"
         },
         {
             "rpc_url": "LUKSO WSS RPC HERE",
+            "fallback_rpcs":["LUKSO WSS RPC HERE", "LUKSO WSS RPC HERE"],
             "chain_id": 4201,
             "bridge_address": "0x83AE9C9cB7Db728550dC32E40cdF0cB660ba945b"
         }

--- a/core/bridge_fungible.go
+++ b/core/bridge_fungible.go
@@ -43,15 +43,16 @@ func bridgeFungibleTokens(c *LoopsoClient, chain int, transferID [32]byte) {
 		return
 	}
 
+	auth, err := c.Auth(dstChainId)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
 	if !isTokenSupported {
 		// if no --> all attestToken on destination chain
 		att := attestationFromTokenTransfer(tokenTransfer, client)
 
-		auth, err := c.Auth(dstChainId)
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
 		tx, err := dstBridge.AttestToken(auth, att)
 		if err != nil {
 			fmt.Println("failed to attest token: ", err)
@@ -68,11 +69,6 @@ func bridgeFungibleTokens(c *LoopsoClient, chain int, transferID [32]byte) {
 
 	attestationID := attestationID(tokenTransfer.TokenTransfer.TokenAddress, chain)
 
-	auth, err := c.Auth(dstChainId)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
 	tx, err := dstBridge.ReleaseWrappedTokens(auth, tokenTransfer.Amount, tokenTransfer.TokenTransfer.DstAddress, attestationID)
 	if err != nil {
 		fmt.Println("error releasing wrapped tokens: ", err)

--- a/core/bridge_fungible.go
+++ b/core/bridge_fungible.go
@@ -10,20 +10,20 @@ import (
 	"github.com/useloopso/BMR/contracts"
 )
 
-func bridgeFungibleTokens(c *LoopsoClient, chain int, transferID [32]byte) {
+func (c *LoopsoClient) bridgeFungibleTokens(chain int, transferID [32]byte) error {
 	chainInfo := c.chainInfos[chain]
 	client := c.conns[chain]
 
 	srcBridge, err := contracts.NewLoopso(common.HexToAddress(chainInfo.BridgeAddress), client)
 	if err != nil {
 		fmt.Println("failed to init bridge contract: ", err)
-		return
+		return err
 	}
 
 	tokenTransfer, err := srcBridge.TokenTransfers(nil, transferID)
 	if err != nil {
 		fmt.Println(err)
-		return
+		return err
 	}
 
 	dstChainId := int(tokenTransfer.TokenTransfer.DstChain.Int64())
@@ -33,20 +33,20 @@ func bridgeFungibleTokens(c *LoopsoClient, chain int, transferID [32]byte) {
 	dstBridge, err := contracts.NewLoopso(common.HexToAddress(dstBridgeAddress), dstBridgeClient)
 	if err != nil {
 		fmt.Println("failed to init bridge: ", err)
-		return
+		return err
 	}
 
 	// check whether token is supported already
 	isTokenSupported, err := dstBridge.IsTokenSupported(nil, tokenTransfer.TokenTransfer.TokenAddress, big.NewInt(int64(chain)))
 	if err != nil {
 		fmt.Println("failed to check is token supported:", err)
-		return
+		return err
 	}
 
 	auth, err := c.Auth(dstChainId)
 	if err != nil {
 		fmt.Println(err)
-		return
+		return err
 	}
 
 	if !isTokenSupported {
@@ -56,14 +56,14 @@ func bridgeFungibleTokens(c *LoopsoClient, chain int, transferID [32]byte) {
 		tx, err := dstBridge.AttestToken(auth, att)
 		if err != nil {
 			fmt.Println("failed to attest token: ", err)
-			return
+			return err
 		}
 		fmt.Println("attest token tx hash: ", tx.Hash())
 
 		_, err = bind.WaitMined(context.Background(), dstBridgeClient, tx)
 		if err != nil {
 			fmt.Println("failed to wait for attest token tx to be mined: ", err)
-			return
+			return err
 		}
 	}
 
@@ -72,25 +72,26 @@ func bridgeFungibleTokens(c *LoopsoClient, chain int, transferID [32]byte) {
 	tx, err := dstBridge.ReleaseWrappedTokens(auth, tokenTransfer.Amount, tokenTransfer.TokenTransfer.DstAddress, attestationID)
 	if err != nil {
 		fmt.Println("error releasing wrapped tokens: ", err)
-		return
+		return err
 	}
 	fmt.Println("tx hash: ", tx.Hash())
+	return nil
 }
 
-func bridgeFungibleTokensBack(c *LoopsoClient, chain int, amount *big.Int, dstAddress common.Address, attestationID [32]byte) {
+func (c *LoopsoClient) bridgeFungibleTokensBack(chain int, amount *big.Int, dstAddress common.Address, attestationID [32]byte) error {
 	chainInfo := c.chainInfos[chain]
 	client := c.conns[chain]
 
 	srcBridge, err := contracts.NewLoopso(common.HexToAddress(chainInfo.BridgeAddress), client)
 	if err != nil {
 		fmt.Println("failed to init bridge contract: ", err)
-		return
+		return err
 	}
 
 	attestedToken, err := srcBridge.AttestedTokens(nil, attestationID)
 	if err != nil {
 		fmt.Println(err)
-		return
+		return err
 	}
 
 	dstChainId := int(attestedToken.TokenChain.Int64())
@@ -100,19 +101,20 @@ func bridgeFungibleTokensBack(c *LoopsoClient, chain int, amount *big.Int, dstAd
 	dstBridge, err := contracts.NewLoopso(common.HexToAddress(dstBridgeAddress), dstBridgeClient)
 	if err != nil {
 		fmt.Println("failed to init bridge: ", err)
-		return
+		return err
 	}
 
 	auth, err := c.Auth(dstChainId)
 	if err != nil {
 		fmt.Println(err)
-		return
+		return err
 	}
 
 	tx, err := dstBridge.ReleaseTokens(auth, amount, dstAddress, attestedToken.TokenAddress)
 	if err != nil {
 		fmt.Println("error bridging tokens back: ", err)
-		return
+		return err
 	}
 	fmt.Println("tx hash: ", tx.Hash())
+	return nil
 }

--- a/core/bridge_non_fungible.go
+++ b/core/bridge_non_fungible.go
@@ -42,14 +42,15 @@ func bridgeNonFungibleTokens(c *LoopsoClient, chain int, transferID [32]byte) {
 		return
 	}
 
+	auth, err := c.Auth(dstChainId)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
 	if !isFungibleTokenSupported {
 		// if no --> all attestToken on destination chain
 		att := attestationFromNonFungibleTokenTransfer(nonFungibleTokenTransfer, client)
-		auth, err := c.Auth(dstChainId)
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
 		tx, err := dstBridge.AttestToken(auth, att)
 		if err != nil {
 			fmt.Println("failed to attest token: ", err)
@@ -65,11 +66,6 @@ func bridgeNonFungibleTokens(c *LoopsoClient, chain int, transferID [32]byte) {
 	}
 
 	attestationID := attestationID(nonFungibleTokenTransfer.TokenTransfer.TokenAddress, chain)
-	auth, err := c.Auth(dstChainId)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
 	tx, err := dstBridge.ReleaseWrappedNonFungibleTokens(auth, nonFungibleTokenTransfer.TokenID, nonFungibleTokenTransfer.TokenURI, nonFungibleTokenTransfer.TokenTransfer.DstAddress, attestationID)
 	if err != nil {
 		fmt.Println("error releasing wrapped non-fungible tokens: ", err)

--- a/core/client.go
+++ b/core/client.go
@@ -1,9 +1,12 @@
 package core
 
 import (
+	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/useloopso/BMR/config"
@@ -13,12 +16,14 @@ import (
 type LoopsoClient struct {
 	conns      map[int]*ethclient.Client
 	chainInfos map[int]types.ChainInfo
+	retryCount int
 }
 
 func NewClient(chains []types.ChainInfo) (*LoopsoClient, error) {
 	var c LoopsoClient
 	c.conns = make(map[int]*ethclient.Client)
 	c.chainInfos = make(map[int]types.ChainInfo)
+	c.retryCount = 3
 
 	for _, cInfo := range chains {
 		client, err := ethclient.Dial(cInfo.RpcURL)
@@ -30,6 +35,49 @@ func NewClient(chains []types.ChainInfo) (*LoopsoClient, error) {
 	}
 
 	return &c, nil
+}
+
+type loopsoEventHandler func(c *LoopsoClient, chain int, log ethtypes.Log) error
+
+/*
+retry on error will be called to handle errors on any of the event handlers
+- go through the fallback rpcs
+- replace current RPC with fallback RPC
+- call failed func again
+- if error == nil, return nil
+- else try again with next fallback rpc
+*/
+func (c *LoopsoClient) RetryOnError(handler loopsoEventHandler, chain int, log ethtypes.Log) error {
+	if len(c.chainInfos[chain].FallbackRpcs) == 0 {
+		return errors.New("no fallback RPCs in chain config")
+	}
+
+	for i := 0; i < c.retryCount; i++ {
+		fmt.Println("retrying...")
+		for j, fallbackRpc := range c.chainInfos[chain].FallbackRpcs {
+			client, err := ethclient.Dial(fallbackRpc)
+			if err != nil {
+				fmt.Println("Fallback rpc connect error: ", err)
+				continue
+			}
+
+			oldClient := c.conns[chain]
+			c.conns[chain] = client
+
+			err = handler(c, chain, log)
+			if err == nil {
+				oldClient.Close()
+				fmt.Println("call successful with fallback RPC")
+				return nil
+			}
+
+			fmt.Println("call failed with fallback RPC no. ", j, " error: ", err)
+			c.conns[chain].Close()
+			c.conns[chain] = oldClient
+		}
+	}
+
+	return errors.New("call failed with all fallback RPCs")
 }
 
 func (c *LoopsoClient) Auth(chainId int) (*bind.TransactOpts, error) {

--- a/core/client.go
+++ b/core/client.go
@@ -1,9 +1,6 @@
 package core
 
 import (
-	"context"
-	"crypto/ecdsa"
-	"errors"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -40,24 +37,12 @@ func (c *LoopsoClient) Auth(chainId int) (*bind.TransactOpts, error) {
 	if err != nil {
 		return nil, err
 	}
-	pubKey := privKey.Public()
-	publicKeyECDSA, ok := pubKey.(*ecdsa.PublicKey)
-	if !ok {
-		return nil, errors.New("error casting public key to ECDSA")
-	}
-	fromAddress := crypto.PubkeyToAddress(*publicKeyECDSA)
-
-	nonce, err := c.conns[chainId].PendingNonceAt(context.Background(), fromAddress)
-	if err != nil {
-		return nil, err
-	}
 
 	auth, err := bind.NewKeyedTransactorWithChainID(privKey, big.NewInt(int64(chainId)))
 	if err != nil {
 		return nil, err
 	}
-	auth.Nonce = big.NewInt(int64(nonce))
-	auth.Value = big.NewInt(0)
+
 	return auth, nil
 }
 

--- a/core/listen.go
+++ b/core/listen.go
@@ -36,11 +36,11 @@ func (c *LoopsoClient) Listen(chain int, wg *sync.WaitGroup, stopCh <-chan struc
 		Addresses: []common.Address{address},
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	/* ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() */
 
 	logs := make(chan ethtypes.Log)
-	sub, err := c.conns[chain].SubscribeFilterLogs(ctx, query, logs)
+	sub, err := c.conns[chain].SubscribeFilterLogs(context.Background(), query, logs)
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func (c *LoopsoClient) Listen(chain int, wg *sync.WaitGroup, stopCh <-chan struc
 				return nil // Stop listening if signaled during backoff
 			}
 
-			sub, err = c.conns[chain].SubscribeFilterLogs(ctx, query, logs)
+			sub, err = c.conns[chain].SubscribeFilterLogs(context.Background(), query, logs)
 			if err != nil {
 				return err
 			}

--- a/core/listen.go
+++ b/core/listen.go
@@ -78,7 +78,7 @@ func (c *LoopsoClient) Listen(chain int, wg *sync.WaitGroup, stopCh <-chan struc
 
 			fmt.Println("listening on chain ID: ", chain)
 		case vLog := <-logs:
-			go HandleEvent(c, chain, vLog)
+			go c.HandleEvent(chain, vLog)
 		}
 	}
 }

--- a/core/listen.go
+++ b/core/listen.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -36,19 +35,16 @@ func (c *LoopsoClient) Listen(chain int, wg *sync.WaitGroup, stopCh <-chan struc
 		Addresses: []common.Address{address},
 	}
 
-	/* ctx, cancel := context.WithCancel(context.Background())
-	defer cancel() */
-
 	logs := make(chan ethtypes.Log)
+
+	c.conns[chain].SubscribeNewHead(context.Background(), make(chan *ethtypes.Header))
+
 	sub, err := c.conns[chain].SubscribeFilterLogs(context.Background(), query, logs)
 	if err != nil {
 		return err
 	}
 
 	fmt.Println("Listening on chain ID:", chain)
-
-	const maxReconnectAttempts = 3
-	reconnectAttempts := 0
 
 	for {
 		select {
@@ -57,18 +53,12 @@ func (c *LoopsoClient) Listen(chain int, wg *sync.WaitGroup, stopCh <-chan struc
 		case err := <-sub.Err():
 			fmt.Println("Failed to get event log: ", err)
 
-			reconnectAttempts++
-			if reconnectAttempts > maxReconnectAttempts {
-				return fmt.Errorf("maximum reconnection attempts reached")
-			}
-
-			backoff := time.Duration(reconnectAttempts) * time.Second
-			fmt.Printf("Reconnecting in %v...\n", backoff)
-
-			select {
-			case <-time.After(backoff):
-			case <-stopCh:
-				return nil // Stop listening if signaled during backoff
+			if err := c.tryReconnect(chain, 3, 1); err != nil {
+				fmt.Println("failed to reconnect to RPC: ", err)
+				if err := c.connectToFallback(chainInfo); err != nil {
+					fmt.Println("all connections failed to chain ", chainInfo.ChainID)
+					return err
+				}
 			}
 
 			sub, err = c.conns[chain].SubscribeFilterLogs(context.Background(), query, logs)
@@ -76,7 +66,8 @@ func (c *LoopsoClient) Listen(chain int, wg *sync.WaitGroup, stopCh <-chan struc
 				return err
 			}
 
-			fmt.Println("listening on chain ID: ", chain)
+			fmt.Println("reconnected to RPC on chain ID: ", chain)
+
 		case vLog := <-logs:
 			go c.HandleEvent(chain, vLog)
 		}

--- a/types/config.go
+++ b/types/config.go
@@ -6,7 +6,8 @@ type ConfigInfo struct {
 }
 
 type ChainInfo struct {
-	RpcURL        string `mapstructure:"rpc_url"`
-	ChainID       int    `mapstructure:"chain_id"`
-	BridgeAddress string `mapstructure:"bridge_address"`
+	RpcURL        string   `mapstructure:"rpc_url"`
+	FallbackRpcs  []string `mapstructure:"fallback_rpcs"`
+	ChainID       int      `mapstructure:"chain_id"`
+	BridgeAddress string   `mapstructure:"bridge_address"`
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,17 +2,8 @@ package utils
 
 import (
 	"bytes"
-	"reflect"
 )
 
 func EncodePacked(input ...[]byte) []byte {
 	return bytes.Join(input, nil)
-}
-
-func ToReflectValue(args []interface{}) []reflect.Value {
-	convertedArgs := make([]reflect.Value, len(args))
-	for i, arg := range args {
-		convertedArgs[i] = reflect.ValueOf(arg)
-	}
-	return convertedArgs
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,7 +1,18 @@
 package utils
 
-import "bytes"
+import (
+	"bytes"
+	"reflect"
+)
 
 func EncodePacked(input ...[]byte) []byte {
 	return bytes.Join(input, nil)
+}
+
+func ToReflectValue(args []interface{}) []reflect.Value {
+	convertedArgs := make([]reflect.Value, len(args))
+	for i, arg := range args {
+		convertedArgs[i] = reflect.ValueOf(arg)
+	}
+	return convertedArgs
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,8 +2,16 @@ package utils
 
 import (
 	"bytes"
+	"context"
+
+	"github.com/ethereum/go-ethereum/ethclient"
 )
 
 func EncodePacked(input ...[]byte) []byte {
 	return bytes.Join(input, nil)
+}
+
+func IsClientConnected(client *ethclient.Client) bool {
+	_, err := client.BlockNumber(context.Background())
+	return err == nil
 }


### PR DESCRIPTION
Implements #4

When an error is thrown, we call `RetryOnError`. This function checks the connectedness of the RPCs on all supported chains, and if it finds a faulty connection it tires to connect to a fallback RPC. Once the faulty connections have been replaced it tries to call the function that errored again.